### PR TITLE
GPU delegate

### DIFF
--- a/gpu_delegate.go
+++ b/gpu_delegate.go
@@ -1,0 +1,39 @@
+package tflite
+
+/*
+#include "tensorflow/lite/delegates/gpu/gl_delegate.h"
+#cgo CFLAGS: -I${SRCDIR}/../../tensorflow/tensorflow
+#cgo LDFLAGS: -L${SRCDIR}/../../tensorflow/tensorflow/tensorflow/lite/experimental/c -ltensorflowlite_gpu_gl
+#cgo pkg-config: egl glesv2
+#cgo linux LDFLAGS: -ldl -lrt
+*/
+import "C"
+
+type GPUDelegate struct {
+	o *C.TfLiteDelegate
+}
+
+type GPUDelegateOptions struct {
+	o *C.TfLiteGpuDelegateOptions
+}
+
+func NewGPUDelegateOptionsDefault() *GPUDelegateOptions {
+	o := C.TfLiteGpuDelegateOptionsDefault()
+	return &GPUDelegateOptions{o: &o}
+}
+
+func NewGPUDelegate(options *GPUDelegateOptions) *GPUDelegate {
+	if options == nil {
+		options = NewGPUDelegateOptionsDefault()
+	}
+	d := C.TfLiteGpuDelegateCreate(options.o)
+	return &GPUDelegate{o: d}
+}
+
+func (d *GPUDelegate) d() *C.TfLiteDelegate {
+	return d.o
+}
+
+func (d *GPUDelegate) Delete() {
+	C.TfLiteGpuDelegateDelete(d.d())
+}

--- a/tflite.go
+++ b/tflite.go
@@ -67,6 +67,11 @@ func (o *InterpreterOptions) SetNumThread(num_threads int) {
 	C.TfLiteInterpreterOptionsSetNumThreads(o.o, C.int32_t(num_threads))
 }
 
+// Add delegate to interpreter
+func (o *InterpreterOptions) AddDelegate(delegate Delegate) {
+	C.TfLiteInterpreterOptionsAddDelegate(o.o, delegate.d())
+}
+
 // SetErrorRepoter set a function of reporter.
 func (o *InterpreterOptions) SetErrorReporter(f func(string, interface{}), user_data interface{}) {
 	C._TfLiteInterpreterOptionsSetErrorReporter(o.o, pointer.Save(&callbackInfo{
@@ -78,6 +83,10 @@ func (o *InterpreterOptions) SetErrorReporter(f func(string, interface{}), user_
 // Delete delete instance of InterpreterOptions.
 func (o *InterpreterOptions) Delete() {
 	C.TfLiteInterpreterOptionsDelete(o.o)
+}
+
+type Delegate interface {
+	d() *C.TfLiteDelegate
 }
 
 // Interpreter implement TfLiteInterpreter.


### PR DESCRIPTION
added a gpu delegate with high level API. Simply add

```
delegate := tflite.NewGPUDelegate(nil)
if delegate == nil {
	log.Fatal("cannot create delegate")
}
defer delegate.Delete()
```

and 

```
options := tflite.NewInterpreterOptions()
...
options.AddDelegate(delegate)
```

However, at the moment of writing, my GPU delegate throws

> INFO: Created TensorFlow Lite delegate for GPU.
> Next operations are not supported by GPU delegate:
> ADD: 
> AVERAGE_POOL_2D: 
> CONV_2D: 
> DEPTHWISE_CONV_2D: 
> RESHAPE: 
> First 0 operations will run on the GPU, and the remaining 65 on the CPU.

for a simple mobilenet_v2 model