### PR TITLE
Fix memory corruption due to go pointer to model data.

### DIFF
--- a/tflite.go
+++ b/tflite.go
@@ -25,7 +25,7 @@ type Model struct {
 
 // NewModel create new Model from buffer.
 func NewModel(model_data []byte) *Model {
-	m := C.TfLiteModelCreate(unsafe.Pointer(&model_data[0]), C.size_t(len(model_data)))
+	m := C.TfLiteModelCreate(C.CBytes(model_data), C.size_t(len(model_data)))
 	if m == nil {
 		return nil
 	}


### PR DESCRIPTION
https://www.tensorflow.org/lite/guide/inference#load_and_run_a_model_in_c

> Caution: The FlatBufferModel object must remain valid until all
> instances of Interpreter using it have been destroyed.

This means that the pointer to the memory is retained by the C code.
However, passing a pointer to Go allocated memory directly is forbidden
(https://golang.org/cmd/cgo/#hdr-Passing_pointers):

> C code may not keep a copy of a Go pointer after the call returns.
> This includes the GoString type, which, as noted above, includes a Go
> pointer; GoString values may not be retained by C code.

This code changes NewModel to use C.CBytes which will malloc memory in C
and copy the data.