### PR TITLE
Add SetUseNNAPI interface

### DIFF
--- a/tflite_experimental.go
+++ b/tflite_experimental.go
@@ -314,6 +314,11 @@ func (o *InterpreterOptions) ExpAddCustomOp(name string, reg *ExpRegistration, m
 	C.TfLiteInterpreterOptionsAddCustomOp(o.o, ptr, r, C.int(minVersion), C.int(maxVersion))
 }
 
+// SetUseNNAPI enable or disable the NN API for the interpreter (true to enable).
+func (o *InterpreterOptions) SetUseNNAPI(enable bool) {
+	C.TfLiteInterpreterOptionsSetUseNNAPI(o.o, C.bool(enable))
+}
+
 // DynamicBuffer is buffer hold multiple strings.
 type DynamicBuffer struct {
 	data   bytes.Buffer


### PR DESCRIPTION
Add an interface `SetUseNNAPI` calling C api `C.TfLiteInterpreterOptionsSetUseNNAPI`, to enable or disable the `NN API` for the interpreter. It is defined in `tensorflow/lite/c/c_api_experimental.h`.
`NN API` delegate is used on android, but my test result of inference time is **not** better than `XNNPACK` or even `multi thread`. Maybe other model can take benefit of this delegate.