### PR TITLE
remove -lrt for android build

### DIFF
--- a/tflite.go
+++ b/tflite.go
@@ -5,7 +5,8 @@ package tflite
 #include "tflite.go.h"
 #endif
 #cgo LDFLAGS: -ltensorflowlite_c
-#cgo linux LDFLAGS: -ldl -lrt
+#cgo android LDFLAGS: -ldl
+#cgo linux,!android LDFLAGS: -ldl -lrt
 */
 import "C"
 import (


### PR DESCRIPTION
Hi, this is my first PR to this repo and hoping you are accepting these sort of changes. Please let me know if there is any guideline that I should be following. thank you.

Removing -lrt flag for android build as there is no separate librt for android ndk.