### PR TITLE
Add cgo flags for android

### DIFF
--- a/delegates/xnnpack/xnnpack.go
+++ b/delegates/xnnpack/xnnpack.go
@@ -4,7 +4,8 @@ package xnnpack
 #ifndef GO_XNNPACK_H
 #include "xnnpack.go.h"
 #endif
-#cgo LDFLAGS: -ltensorflowlite-delegate_xnnpack -lXNNPACK
+#cgo LDFLAGS: -ltensorflowlite_c
+#cgo android LDFLAGS: -lm -llog
 */
 import "C"
 import (

--- a/tflite.go
+++ b/tflite.go
@@ -5,7 +5,7 @@ package tflite
 #include "tflite.go.h"
 #endif
 #cgo LDFLAGS: -ltensorflowlite_c
-#cgo android LDFLAGS: -ldl
+#cgo android LDFLAGS: -ldl -llog -lm
 #cgo linux,!android LDFLAGS: -ldl -lrt
 */
 import "C"


### PR DESCRIPTION
The pull request [remove -lrt for android build #37](https://github.com/mattn/go-tflite/pull/37) solved some of my issues. I used to change the `cgo LDFLAGS` every time I switch testing `amd64` / `arm32` / `arm64`. These two flags `cgo android` and `cgo linux,!android` work like a charm!

### Commit changes
- Adding two other library flags `-lm -llog` for android, which is needed when building `android aar library` using `gomobile bind`.
- Using `-ltensorflowlite_c` instead of `-ltensorflowlite-delegate_xnnpack -lXNNPACK` in `delegates/xnnpack/xnnpack.go`. I'm not sure if I'm right about this. In my practice, compiling lib using
  ```sh
  $ bazel build --config opt --config monolithic  --define tflite_with_xnnpack=true //tensorflow/lite:libtensorflowlite.so
  $ bazel build --config opt --config monolithic  --define tflite_with_xnnpack=true //tensorflow/lite/c:libtensorflowlite_c.so
  ```
  will include `xnnpack` in `libtensorflowlite_c.so`. This seems easier in using of `xnnpack`.
- In my basic tests, `-ldl -lrt` is not required for both `linux` and `android`, maybe they are not for my testing scenarios.

### Testing Android flags
- **Project folder structure**
  ```sh
  $ tree testTflite/
  # testTflite/
  # ├── main.go
  # └── runTest
  #     └── runTest.go
  ```
- **runTest/runTest.go**
  ```go
  package runTest

  import (
  	"fmt"
  	"github.com/mattn/go-tflite"
  	"github.com/mattn/go-tflite/delegates/xnnpack"
  )

  func Run(model_path string) {
  	model := tflite.NewModelFromFile(model_path)
  	options := tflite.NewInterpreterOptions()
  	options.AddDelegate(xnnpack.New(xnnpack.DelegateOptions{NumThreads: 2}))
  	defer options.Delete()

  	interp := tflite.NewInterpreter(model, options)
  	status := interp.AllocateTensors()
  	input := interp.GetInputTensor(0)
  	in := input.Float32s()
  	fmt.Println(status, len(in))
  	status = interp.Invoke()
  	output := interp.GetOutputTensor(0).Float32s()
  	fmt.Println(output)
  }
  ```
- **main.go**
  ```go
  package main

  import "testTflite/runTest"

  func main() {
  	runTest.Run("model.tflite")
  }
  ```
- **Test**
  ```sh
  cd testTflite
  go mod init testTflite
  # Use my custom go-tflite
  go mod edit -replace=github.com/mattn/go-tflite=$HOME/workspace/go-tflite
  go mod tidy

  # Build test for amd64
  export CGO_LDFLAGS=-L$HOME/workspace/tensorflow/bazel-bin/tensorflow/lite/c
  export CGO_CFLAGS=-I$HOME/workspace/tensorflow/
  go build main.go
  ```
  ```sh
  # Build test for arm64
  export CGO_LDFLAGS="-L$HOME/workspace/tensorflow.arm64/bazel-bin/tensorflow/lite/c"
  export CGO_CFLAGS="-I$HOME/workspace/tensorflow.arm64/"
  SDK_HOME="$HOME/Android/Sdk/ndk/21.0.6113669/toolchains/llvm/prebuilt/linux-x86_64"
  ANDROID_CC="$SDK_HOME/bin/aarch64-linux-android29-clang -Wl,-rpath-link,$SDK_HOME/sysroot/usr/lib/aarch64-linux-android/29"
  ANDROID_CXX="$SDK_HOME/bin/aarch64-linux-android29-clang++ -Wl,-rpath-link,$SDK_HOME/sysroot/usr/lib/aarch64-linux-android/29"
  ANDROID_ARCH="arm64"
  CGO_ENABLED=1 GOOS=android GOARCH=$ANDROID_ARCH CC=$ANDROID_CC CXX=$ANDROID_CXX go build main.go
  ```
  ```sh
  # gomobile bind test for arm64, will throw error without `-llog -lm`
  go get golang.org/x/mobile/bind
  gomobile bind -v -o test.aar -target=android/arm64 testTflite/runTest
  ```