### PR TITLE
Update Makefile to support macOS (Intel and Apple Silicon)

### DIFF
--- a/Makefile.tflite
+++ b/Makefile.tflite
@@ -5,13 +5,17 @@ SRCS = \
 OBJS = $(subst .cc,.o,$(subst .cxx,.o,$(subst .cpp,.o,$(SRCS))))
 
 TENSORFLOW_ROOT = $(shell go env GOPATH)/src/github.com/tensorflow/tensorflow
-CXXFLAGS = -fPIC -DTF_COMPILE_LIBRARY -I$(TENSORFLOW_ROOT) \
+CXXFLAGS := -fPIC -DTF_COMPILE_LIBRARY -I$(TENSORFLOW_ROOT) \
 	-I$(TENSORFLOW_ROOT)/tensorflow/lite/tools/make/downloads/flatbuffers/include \
 	-I$(TENSORFLOW_ROOT)/tensorflow/lite/tools/make/downloads/absl
 TARGET = libtensorflowlite_c
 ifeq ($(OS),Windows_NT)
 OS_ARCH = windows_x86_64
 TARGET_SHARED := $(TARGET).dll
+else
+ifeq ($(shell uname -s),Darwin)
+CXXFLAGS := -std=c++11 $(CXXFLAGS)
+OS_ARCH = osx_$(shell uname -m)
 else
 ifeq ($(shell uname -m),x86_64)
 OS_ARCH = linux_x86_64
@@ -20,6 +24,7 @@ ifeq ($(shell uname -m),armv6l)
 OS_ARCH = linux_armv6l
 else
 OS_ARCH = rpi_armv7l
+endif
 endif
 endif
 TARGET_SHARED := $(TARGET).so


### PR DESCRIPTION
This PR made a change to support macOS.

I tested on Intel and M1 Macbook below environment,


### Apple Silicon M1

```bash
$ uname -s
Darwin

$ uname -m
arm64

$ c++ --version
Apple clang version 12.0.0 (clang-1200.0.32.29)
Target: arm64-apple-darwin20.3.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

$ sw_vers
ProductName:	macOS
ProductVersion:	11.2.3
BuildVersion:	20D91
```

### Intel

```bash
$ uname -s
Darwin

$ uname -m
x86_64

$ c++ --version
Apple clang version 11.0.0 (clang-1100.0.33.17)
Target: x86_64-apple-darwin18.7.0
Thread model: posix
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin

$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.14.6
BuildVersion:	18G8022
```
