### PR TITLE
chore: bump to Go 1.25 with CGO performance optimizations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - go
+    commit-message:
+      prefix: "build(deps)"
+    open-pull-requests-limit: 5
+    groups:
+      go-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: "ci(deps)"
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/_example/blazeface/go.mod
+++ b/_example/blazeface/go.mod
@@ -1,10 +1,10 @@
-module github.com/mattn/go-tflite/_example/blazeface
+module github.com/tphakala/go-tflite/_example/blazeface
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
 require (
-	github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+	github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000
 	gocv.io/x/gocv v0.29.0
 )

--- a/_example/blazeface/main.go
+++ b/_example/blazeface/main.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mattn/go-tflite"
+	"github.com/tphakala/go-tflite"
 
 	"gocv.io/x/gocv"
 )

--- a/_example/esrgan/go.mod
+++ b/_example/esrgan/go.mod
@@ -1,10 +1,10 @@
-module github.com/mattn/go-tflite/_example/esrgan
+module github.com/tphakala/go-tflite/_example/esrgan
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
 require (
-	github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+	github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 )

--- a/_example/esrgan/main.go
+++ b/_example/esrgan/main.go
@@ -10,7 +10,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/mattn/go-tflite"
+	"github.com/tphakala/go-tflite"
 	"github.com/nfnt/resize"
 )
 

--- a/_example/fizzbuzz/Fun with TensorFlow Lite using go-tflite.ipynb
+++ b/_example/fizzbuzz/Fun with TensorFlow Lite using go-tflite.ipynb
@@ -106,7 +106,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import \"github.com/mattn/go-tflite\""
+    "import \"github.com/tphakala/go-tflite\""
    ]
   },
   {

--- a/_example/fizzbuzz/main.go
+++ b/_example/fizzbuzz/main.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mattn/go-tflite"
+	"github.com/tphakala/go-tflite"
 )
 
 func bin(n int, num_digits int) []float32 {

--- a/_example/fizzbuzz_edgetpu/go.mod
+++ b/_example/fizzbuzz_edgetpu/go.mod
@@ -1,9 +1,9 @@
-module github.com/mattn/go-tflite/_example/fizzbuzz_edgetpu
+module github.com/tphakala/go-tflite/_example/fizzbuzz_edgetpu
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
-replace github.com/mattn/go-tflite/delegates/edgetpu => ../../delegates/edgetpu
+replace github.com/tphakala/go-tflite/delegates/edgetpu => ../../delegates/edgetpu
 
-require github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+require github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000

--- a/_example/fizzbuzz_edgetpu/main.go
+++ b/_example/fizzbuzz_edgetpu/main.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mattn/go-tflite"
-	"github.com/mattn/go-tflite/delegates/edgetpu"
+	"github.com/tphakala/go-tflite"
+	"github.com/tphakala/go-tflite/delegates/edgetpu"
 )
 
 func bin(n int, num_digits int) []uint8 {

--- a/_example/iris/main.go
+++ b/_example/iris/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/mattn/go-tflite"
+	"github.com/tphakala/go-tflite"
 )
 
 func loadData() ([][]float32, []string, error) {

--- a/_example/label_image/Classify images using pre-trained model.ipynb
+++ b/_example/label_image/Classify images using pre-trained model.ipynb
@@ -83,7 +83,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import \"github.com/mattn/go-tflite\""
+    "import \"github.com/tphakala/go-tflite\""
    ]
   },
   {

--- a/_example/label_image/go.mod
+++ b/_example/label_image/go.mod
@@ -1,10 +1,10 @@
-module github.com/mattn/go-tflite/_example/label_image
+module github.com/tphakala/go-tflite/_example/label_image
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
 require (
-	github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+	github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 )

--- a/_example/label_image/main.go
+++ b/_example/label_image/main.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"sort"
 
-	"github.com/mattn/go-tflite"
+	"github.com/tphakala/go-tflite"
 	"github.com/nfnt/resize"
 )
 

--- a/_example/label_image_edgetpu/go.mod
+++ b/_example/label_image_edgetpu/go.mod
@@ -1,12 +1,12 @@
-module github.com/mattn/go-tflite/_example/label_image_edgetpu
+module github.com/tphakala/go-tflite/_example/label_image_edgetpu
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
-replace github.com/mattn/go-tflite/delegates/edgetpu => ../../delegates/edgetpu
+replace github.com/tphakala/go-tflite/delegates/edgetpu => ../../delegates/edgetpu
 
 require (
-	github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+	github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 )

--- a/_example/label_image_edgetpu/main.go
+++ b/_example/label_image_edgetpu/main.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"sort"
 
-	"github.com/mattn/go-tflite"
-	"github.com/mattn/go-tflite/delegates/edgetpu"
+	"github.com/tphakala/go-tflite"
+	"github.com/tphakala/go-tflite/delegates/edgetpu"
 	"github.com/nfnt/resize"
 )
 

--- a/_example/label_image_xnnpack/go.mod
+++ b/_example/label_image_xnnpack/go.mod
@@ -1,12 +1,12 @@
-module github.com/mattn/go-tflite/_example/label_image_xnnpack
+module github.com/tphakala/go-tflite/_example/label_image_xnnpack
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
-replace github.com/mattn/go-tflite/delegates/xnnpack => ../../delegates/xnnpack
+replace github.com/tphakala/go-tflite/delegates/xnnpack => ../../delegates/xnnpack
 
 require (
-	github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+	github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 )

--- a/_example/label_image_xnnpack/main.go
+++ b/_example/label_image_xnnpack/main.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"sort"
 
-	"github.com/mattn/go-tflite"
-	"github.com/mattn/go-tflite/delegates/xnnpack"
+	"github.com/tphakala/go-tflite"
+	"github.com/tphakala/go-tflite/delegates/xnnpack"
 	"github.com/nfnt/resize"
 )
 

--- a/_example/mnist/Predicting handwriting number with mnist.ipynb
+++ b/_example/mnist/Predicting handwriting number with mnist.ipynb
@@ -80,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import \"github.com/mattn/go-tflite\""
+    "import \"github.com/tphakala/go-tflite\""
    ]
   },
   {

--- a/_example/mnist/go.mod
+++ b/_example/mnist/go.mod
@@ -1,10 +1,10 @@
-module github.com/mattn/go-tflite/_example/mnist
+module github.com/tphakala/go-tflite/_example/mnist
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
 require (
-	github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+	github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 )

--- a/_example/mnist/main.go
+++ b/_example/mnist/main.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/mattn/go-tflite"
+	"github.com/tphakala/go-tflite"
 	"github.com/nfnt/resize"
 )
 

--- a/_example/mnist_edgetpu/go.mod
+++ b/_example/mnist_edgetpu/go.mod
@@ -1,12 +1,12 @@
-module github.com/mattn/go-tflite/_example/mnist_edgetpu
+module github.com/tphakala/go-tflite/_example/mnist_edgetpu
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
-replace github.com/mattn/go-tflite/delegates/edgetpu => ../../delegates/edgetpu
+replace github.com/tphakala/go-tflite/delegates/edgetpu => ../../delegates/edgetpu
 
 require (
-	github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+	github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 )

--- a/_example/mnist_edgetpu/main.go
+++ b/_example/mnist_edgetpu/main.go
@@ -8,8 +8,8 @@ import (
 	"log"
 	"os"
 
-	"github.com/mattn/go-tflite"
-	"github.com/mattn/go-tflite/delegates/edgetpu"
+	"github.com/tphakala/go-tflite"
+	"github.com/tphakala/go-tflite/delegates/edgetpu"
 	"github.com/nfnt/resize"
 )
 

--- a/_example/mnist_reader/go.mod
+++ b/_example/mnist_reader/go.mod
@@ -1,11 +1,11 @@
-module github.com/mattn/go-tflite/_example/mnist_reader
+module github.com/tphakala/go-tflite/_example/mnist_reader
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
 require (
-	github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+	github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	github.com/vincent-petithory/dataurl v1.0.0
 )

--- a/_example/mnist_reader/main.go
+++ b/_example/mnist_reader/main.go
@@ -8,7 +8,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/mattn/go-tflite"
+	"github.com/tphakala/go-tflite"
 	"github.com/nfnt/resize"
 	"github.com/vincent-petithory/dataurl"
 )

--- a/_example/pose/go.mod
+++ b/_example/pose/go.mod
@@ -1,12 +1,12 @@
-module github.com/mattn/go-tflite/_example/pose
+module github.com/tphakala/go-tflite/_example/pose
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
 require (
 	github.com/llgcode/draw2d v0.0.0-20210904075650-80aa0a2a901d
-	github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+	github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // indirect
 )

--- a/_example/pose/main.go
+++ b/_example/pose/main.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/llgcode/draw2d/draw2dimg"
 	"github.com/llgcode/draw2d/draw2dkit"
-	"github.com/mattn/go-tflite"
+	"github.com/tphakala/go-tflite"
 	"github.com/nfnt/resize"
 )
 

--- a/_example/qa/go.mod
+++ b/_example/qa/go.mod
@@ -1,7 +1,7 @@
-module github.com/mattn/go-tflite/_example/qa
+module github.com/tphakala/go-tflite/_example/qa
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
-require github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+require github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000

--- a/_example/qa/main.go
+++ b/_example/qa/main.go
@@ -14,7 +14,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/mattn/go-tflite"
+	"github.com/tphakala/go-tflite"
 )
 
 var doLowerCase = true

--- a/_example/segment/Draw segments on the picture.ipynb
+++ b/_example/segment/Draw segments on the picture.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "import (\n",
     "    \"log\"\n",
-    "    \"github.com/mattn/go-tflite\"\n",
+    "    \"github.com/tphakala/go-tflite\"\n",
     ")"
    ]
   },

--- a/_example/segment/go.mod
+++ b/_example/segment/go.mod
@@ -1,10 +1,10 @@
-module github.com/mattn/go-tflite/_example/segment
+module github.com/tphakala/go-tflite/_example/segment
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
 require (
-	github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+	github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 )

--- a/_example/segment/main.go
+++ b/_example/segment/main.go
@@ -10,7 +10,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/mattn/go-tflite"
+	"github.com/tphakala/go-tflite"
 	"github.com/nfnt/resize"
 )
 

--- a/_example/sin/Approximate sin function.ipynb
+++ b/_example/sin/Approximate sin function.ipynb
@@ -74,7 +74,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import \"github.com/mattn/go-tflite\""
+    "import \"github.com/tphakala/go-tflite\""
    ]
   },
   {

--- a/_example/sin/main.go
+++ b/_example/sin/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"math"
 
-	"github.com/mattn/go-tflite"
+	"github.com/tphakala/go-tflite"
 )
 
 func main() {

--- a/_example/smartreply/main.go
+++ b/_example/smartreply/main.go
@@ -11,9 +11,9 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/mattn/go-tflite"
-	customOps "github.com/mattn/go-tflite/_example/smartreply/ops"
-	builtinOps "github.com/mattn/go-tflite/ops"
+	"github.com/tphakala/go-tflite"
+	customOps "github.com/tphakala/go-tflite/_example/smartreply/ops"
+	builtinOps "github.com/tphakala/go-tflite/ops"
 )
 
 type result struct {

--- a/_example/smartreply/ops/ops.go
+++ b/_example/smartreply/ops/ops.go
@@ -35,7 +35,7 @@ import (
 	"reflect"
 	"unsafe"
 
-	"github.com/mattn/go-tflite"
+	"github.com/tphakala/go-tflite"
 )
 
 func wrap(p *C.TfLiteRegistration) *tflite.ExpRegistration {

--- a/_example/ssd/Single Short Object Detection.ipynb
+++ b/_example/ssd/Single Short Object Detection.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "import (\n",
     "    \"log\"\n",
-    "    \"github.com/mattn/go-tflite\"\n",
+    "    \"github.com/tphakala/go-tflite\"\n",
     ")"
    ]
   },

--- a/_example/ssd/go.mod
+++ b/_example/ssd/go.mod
@@ -1,11 +1,11 @@
-module github.com/mattn/go-tflite/_example/ssd
+module github.com/tphakala/go-tflite/_example/ssd
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
 require (
-	github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+	github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000
 	gocv.io/x/gocv v0.29.0
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 )

--- a/_example/ssd/main.go
+++ b/_example/ssd/main.go
@@ -14,7 +14,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mattn/go-tflite"
+	"github.com/tphakala/go-tflite"
 
 	"gocv.io/x/gocv"
 	"golang.org/x/image/colornames"

--- a/_example/ssd_edgetpu/go.mod
+++ b/_example/ssd_edgetpu/go.mod
@@ -1,13 +1,13 @@
-module github.com/mattn/go-tflite/_example/ssd_edgetpu
+module github.com/tphakala/go-tflite/_example/ssd_edgetpu
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
-replace github.com/mattn/go-tflite/delegates/edgetpu => ../../delegates/edgetpu
+replace github.com/tphakala/go-tflite/delegates/edgetpu => ../../delegates/edgetpu
 
 require (
-	github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+	github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000
 	gocv.io/x/gocv v0.29.0
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 )

--- a/_example/ssd_edgetpu/main.go
+++ b/_example/ssd_edgetpu/main.go
@@ -14,8 +14,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mattn/go-tflite"
-	"github.com/mattn/go-tflite/delegates/edgetpu"
+	"github.com/tphakala/go-tflite"
+	"github.com/tphakala/go-tflite/delegates/edgetpu"
 
 	"gocv.io/x/gocv"
 	"golang.org/x/image/colornames"

--- a/_example/ssd_gl/go.mod
+++ b/_example/ssd_gl/go.mod
@@ -1,13 +1,13 @@
-module github.com/mattn/go-tflite/_example/ssd_gl
+module github.com/tphakala/go-tflite/_example/ssd_gl
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
-replace github.com/mattn/go-tflite/delegates/gl => ../../delegates/gl
+replace github.com/tphakala/go-tflite/delegates/gl => ../../delegates/gl
 
 require (
-	github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+	github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000
 	gocv.io/x/gocv v0.29.0
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 )

--- a/_example/ssd_gl/main.go
+++ b/_example/ssd_gl/main.go
@@ -14,9 +14,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mattn/go-tflite"
-	"github.com/mattn/go-tflite/delegates/gpu/gl"
-	builtinOps "github.com/mattn/go-tflite/ops"
+	"github.com/tphakala/go-tflite"
+	"github.com/tphakala/go-tflite/delegates/gpu/gl"
+	builtinOps "github.com/tphakala/go-tflite/ops"
 
 	"gocv.io/x/gocv"
 	"golang.org/x/image/colornames"

--- a/_example/ssd_xnnpack/go.mod
+++ b/_example/ssd_xnnpack/go.mod
@@ -1,13 +1,13 @@
-module github.com/mattn/go-tflite/_example/ssd_xnnpack
+module github.com/tphakala/go-tflite/_example/ssd_xnnpack
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
-replace github.com/mattn/go-tflite/delegates/xnnpack => ../../delegates/xnnpack
+replace github.com/tphakala/go-tflite/delegates/xnnpack => ../../delegates/xnnpack
 
 require (
-	github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+	github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000
 	gocv.io/x/gocv v0.29.0
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 )

--- a/_example/ssd_xnnpack/main.go
+++ b/_example/ssd_xnnpack/main.go
@@ -14,8 +14,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mattn/go-tflite"
-	"github.com/mattn/go-tflite/delegates/xnnpack"
+	"github.com/tphakala/go-tflite"
+	"github.com/tphakala/go-tflite/delegates/xnnpack"
 
 	"gocv.io/x/gocv"
 	"golang.org/x/image/colornames"

--- a/_example/style_transform/go.mod
+++ b/_example/style_transform/go.mod
@@ -1,11 +1,11 @@
-module github.com/mattn/go-tflite/_example/style_transform
+module github.com/tphakala/go-tflite/_example/style_transform
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
 require (
 	github.com/disintegration/imaging v1.6.2
-	github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+	github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410 // indirect
 )

--- a/_example/style_transform/main.go
+++ b/_example/style_transform/main.go
@@ -13,7 +13,7 @@ import (
 	"os"
 
 	"github.com/disintegration/imaging"
-	"github.com/mattn/go-tflite"
+	"github.com/tphakala/go-tflite"
 )
 
 func predict(img image.Image, mpredict string) ([]float32, error) {

--- a/_example/text_classification/main.go
+++ b/_example/text_classification/main.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/mattn/go-tflite"
+	"github.com/tphakala/go-tflite"
 )
 
 const (

--- a/_example/webcam/go.mod
+++ b/_example/webcam/go.mod
@@ -1,12 +1,12 @@
-module github.com/mattn/go-tflite/_example/webcam
+module github.com/tphakala/go-tflite/_example/webcam
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
 require (
 	github.com/faiface/pixel v0.10.0
-	github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+	github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000
 	github.com/nfnt/resize v0.0.0-20180221191011-83c6a9932646
 	gocv.io/x/gocv v0.29.0
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410

--- a/_example/webcam/main.go
+++ b/_example/webcam/main.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mattn/go-tflite"
+	"github.com/tphakala/go-tflite"
 	"golang.org/x/image/colornames"
 
 	"github.com/faiface/pixel"

--- a/_example/xor_embedded/go.mod
+++ b/_example/xor_embedded/go.mod
@@ -1,7 +1,7 @@
-module github.com/mattn/go-tflite/_example/xor_embedded
+module github.com/tphakala/go-tflite/_example/xor_embedded
 
 go 1.16
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
-require github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+require github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000

--- a/_example/xor_embedded/main.go
+++ b/_example/xor_embedded/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"math"
 
-	"github.com/mattn/go-tflite"
+	"github.com/tphakala/go-tflite"
 )
 
 //go:embed xor_model.tflite

--- a/_example/yolov3/go.mod
+++ b/_example/yolov3/go.mod
@@ -1,11 +1,11 @@
-module github.com/mattn/go-tflite/_example/yolov3
+module github.com/tphakala/go-tflite/_example/yolov3
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
 require (
-	github.com/mattn/go-tflite v0.0.0-00010101000000-000000000000
+	github.com/tphakala/go-tflite v0.0.0-00010101000000-000000000000
 	gocv.io/x/gocv v0.29.0
 	golang.org/x/image v0.0.0-20211028202545-6944b10bf410
 )

--- a/_example/yolov3/main.go
+++ b/_example/yolov3/main.go
@@ -15,8 +15,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/mattn/go-tflite"
-	"github.com/mattn/go-tflite/delegates/edgetpu"
+	"github.com/tphakala/go-tflite"
+	"github.com/tphakala/go-tflite/delegates/edgetpu"
 	"golang.org/x/image/colornames"
 
 	"gocv.io/x/gocv"

--- a/callback.go
+++ b/callback.go
@@ -8,8 +8,8 @@ import (
 )
 
 type callbackInfo struct {
-	user_data interface{}
-	f         func(msg string, user_data interface{})
+	user_data any
+	f         func(msg string, user_data any)
 }
 
 //export _go_error_reporter

--- a/delegates/edgetpu/edgetpu.go
+++ b/delegates/edgetpu/edgetpu.go
@@ -9,6 +9,14 @@ package edgetpu
 #endif
 #cgo LDFLAGS: -ledgetpu
 
+// Go 1.24+ CGO optimizations
+#cgo noescape edgetpu_create_delegate
+#cgo nocallback edgetpu_create_delegate
+#cgo nocallback edgetpu_free_delegate
+#cgo nocallback edgetpu_version
+#cgo nocallback edgetpu_verbosity
+#cgo nocallback edgetpu_list_devices
+#cgo nocallback edgetpu_free_devices
 */
 import "C"
 import (

--- a/delegates/edgetpu/edgetpu.go
+++ b/delegates/edgetpu/edgetpu.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 	"unsafe"
 
-	"github.com/mattn/go-tflite/delegates"
+	"github.com/tphakala/go-tflite/delegates"
 )
 
 const (

--- a/delegates/external/external.go
+++ b/delegates/external/external.go
@@ -13,7 +13,7 @@ import (
 	"errors"
 	"unsafe"
 
-	"github.com/mattn/go-tflite/delegates"
+	"github.com/tphakala/go-tflite/delegates"
 )
 
 type DelegateOptions struct {

--- a/delegates/external/external.go
+++ b/delegates/external/external.go
@@ -7,6 +7,15 @@ package external
 #cgo CFLAGS: -std=c99
 #cgo CXXFLAGS: -std=c99
 #cgo LDFLAGS: -ltensorflowlite-delegate_external
+
+// Go 1.24+ CGO optimizations
+#cgo noescape TfLiteExternalDelegateOptionsDefault
+#cgo noescape TfLiteExternalDelegateOptionsInsert
+#cgo noescape TfLiteExternalDelegateCreate
+#cgo nocallback TfLiteExternalDelegateOptionsDefault
+#cgo nocallback TfLiteExternalDelegateOptionsInsert
+#cgo nocallback TfLiteExternalDelegateCreate
+#cgo nocallback TfLiteExternalDelegateDelete
 */
 import "C"
 import (

--- a/delegates/gpu/cl/cl.go
+++ b/delegates/gpu/cl/cl.go
@@ -6,6 +6,10 @@ package cl
 #endif
 #cgo LDFLAGS: -ltensorflowlite_c -ltensorflowlite_c_delegate_gpu
 #cgo linux LDFLAGS: -ldl -lrt
+
+// Go 1.24+ CGO optimizations
+#cgo nocallback TfLiteGpuDelegateCreate_New
+#cgo nocallback TfLiteGpuDelegateDelete_New
 */
 import "C"
 import (

--- a/delegates/gpu/cl/cl.go
+++ b/delegates/gpu/cl/cl.go
@@ -11,7 +11,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/mattn/go-tflite/delegates"
+	"github.com/tphakala/go-tflite/delegates"
 )
 
 // GpuCompileOptions implement TfLiteGpuCompileOptions.

--- a/delegates/gpu/gl/gl.go
+++ b/delegates/gpu/gl/gl.go
@@ -7,6 +7,10 @@ package gl
 #cgo pkg-config: osmesa
 #cgo LDFLAGS: -ltensorflowlite_c -ltensorflowlite_c_delegate_gpu
 #cgo linux LDFLAGS: -ldl -lrt
+
+// Go 1.24+ CGO optimizations
+#cgo nocallback TfLiteGpuDelegateCreate
+#cgo nocallback TfLiteGpuDelegateDelete
 */
 import "C"
 import (

--- a/delegates/gpu/gl/gl.go
+++ b/delegates/gpu/gl/gl.go
@@ -12,7 +12,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/mattn/go-tflite/delegates"
+	"github.com/tphakala/go-tflite/delegates"
 )
 
 // GpuCompileOptions implement TfLiteGpuCompileOptions.

--- a/delegates/lib/go.mod
+++ b/delegates/lib/go.mod
@@ -1,10 +1,10 @@
-module github.com/mattn/go-tflite/delegates/lib
+module github.com/tphakala/go-tflite/delegates/lib
 
 go 1.13
 
-replace github.com/mattn/go-tflite => ../..
+replace github.com/tphakala/go-tflite => ../..
 
 require (
 	github.com/coreos/pkg v0.0.0-20220810130054-c7d1c02cb6cf // indirect
-	github.com/mattn/go-tflite v1.0.3 // indirect
+	github.com/tphakala/go-tflite v1.0.3 // indirect
 )

--- a/delegates/lib/lib.go
+++ b/delegates/lib/lib.go
@@ -37,7 +37,7 @@ import (
 	"unsafe"
 
 	"github.com/coreos/pkg/dlopen"
-	"github.com/mattn/go-tflite/delegates"
+	"github.com/tphakala/go-tflite/delegates"
 )
 
 // LibDelegate implement Delegater

--- a/delegates/xnnpack/xnnpack.go
+++ b/delegates/xnnpack/xnnpack.go
@@ -4,7 +4,7 @@ package xnnpack
 #ifndef GO_XNNPACK_H
 #include "xnnpack.go.h"
 #endif
-#cgo LDFLAGS: -ltensorflowlite-delegate_xnnpack -lXNNPACK
+#cgo LDFLAGS: -lXNNPACK
 */
 import "C"
 import (

--- a/delegates/xnnpack/xnnpack.go
+++ b/delegates/xnnpack/xnnpack.go
@@ -10,7 +10,7 @@ import "C"
 import (
 	"unsafe"
 
-	"github.com/mattn/go-tflite/delegates"
+	"github.com/tphakala/go-tflite/delegates"
 )
 
 type DelegateOptions struct {

--- a/delegates/xnnpack/xnnpack.go
+++ b/delegates/xnnpack/xnnpack.go
@@ -5,6 +5,12 @@ package xnnpack
 #include "xnnpack.go.h"
 #endif
 #cgo LDFLAGS: -ltensorflowlite_c
+
+// Go 1.24+ CGO optimizations
+#cgo noescape TfLiteXNNPackDelegateCreate
+#cgo nocallback TfLiteXNNPackDelegateOptionsDefault
+#cgo nocallback TfLiteXNNPackDelegateCreate
+#cgo nocallback TfLiteXNNPackDelegateDelete
 */
 import "C"
 import (

--- a/delegates/xnnpack/xnnpack.go
+++ b/delegates/xnnpack/xnnpack.go
@@ -4,7 +4,7 @@ package xnnpack
 #ifndef GO_XNNPACK_H
 #include "xnnpack.go.h"
 #endif
-#cgo LDFLAGS: -lXNNPACK
+#cgo LDFLAGS: -ltensorflowlite_c
 */
 import "C"
 import (

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/tphakala/go-tflite
 
-go 1.21
+go 1.25
 
 require github.com/mattn/go-pointer v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/mattn/go-tflite
+module github.com/tphakala/go-tflite
 
-go 1.13
+go 1.21
 
 require github.com/mattn/go-pointer v0.0.1

--- a/ops/ops.go
+++ b/ops/ops.go
@@ -130,7 +130,7 @@ import (
 	"reflect"
 	"unsafe"
 
-	"github.com/mattn/go-tflite"
+	"github.com/tphakala/go-tflite"
 )
 
 func wrap(p *C.TfLiteRegistration) *tflite.ExpRegistration {
@@ -143,18 +143,20 @@ func wrap(p *C.TfLiteRegistration) *tflite.ExpRegistration {
 	}
 }
 
-func Register_ABS() *tflite.ExpRegistration               { return wrap(C.Register_ABS()) }
-func Register_RELU() *tflite.ExpRegistration              { return wrap(C.Register_RELU()) }
-func Register_RELU_N1_TO_1() *tflite.ExpRegistration      { return wrap(C.Register_RELU_N1_TO_1()) }
-func Register_RELU6() *tflite.ExpRegistration             { return wrap(C.Register_RELU6()) }
-func Register_TANH_REF() *tflite.ExpRegistration          { return wrap(C.Register_TANH_REF()) }
-func Register_LOGISTIC_REF() *tflite.ExpRegistration      { return wrap(C.Register_LOGISTIC_REF()) }
-func Register_AVERAGE_POOL_REF() *tflite.ExpRegistration  { return wrap(C.Register_AVERAGE_POOL_REF()) }
-func Register_MAX_POOL_REF() *tflite.ExpRegistration      { return wrap(C.Register_MAX_POOL_REF()) }
-func Register_L2_POOL_REF() *tflite.ExpRegistration       { return wrap(C.Register_L2_POOL_REF()) }
-func Register_CONV_2D() *tflite.ExpRegistration           { return wrap(C.Register_CONV_2D()) }
-func Register_CONVOLUTION_REF() *tflite.ExpRegistration   { return wrap(C.Register_CONVOLUTION_REF()) }
-func Register_DEPTHWISE_CONV_2D() *tflite.ExpRegistration { return wrap(C.Register_DEPTHWISE_CONV_2D()) }
+func Register_ABS() *tflite.ExpRegistration              { return wrap(C.Register_ABS()) }
+func Register_RELU() *tflite.ExpRegistration             { return wrap(C.Register_RELU()) }
+func Register_RELU_N1_TO_1() *tflite.ExpRegistration     { return wrap(C.Register_RELU_N1_TO_1()) }
+func Register_RELU6() *tflite.ExpRegistration            { return wrap(C.Register_RELU6()) }
+func Register_TANH_REF() *tflite.ExpRegistration         { return wrap(C.Register_TANH_REF()) }
+func Register_LOGISTIC_REF() *tflite.ExpRegistration     { return wrap(C.Register_LOGISTIC_REF()) }
+func Register_AVERAGE_POOL_REF() *tflite.ExpRegistration { return wrap(C.Register_AVERAGE_POOL_REF()) }
+func Register_MAX_POOL_REF() *tflite.ExpRegistration     { return wrap(C.Register_MAX_POOL_REF()) }
+func Register_L2_POOL_REF() *tflite.ExpRegistration      { return wrap(C.Register_L2_POOL_REF()) }
+func Register_CONV_2D() *tflite.ExpRegistration          { return wrap(C.Register_CONV_2D()) }
+func Register_CONVOLUTION_REF() *tflite.ExpRegistration  { return wrap(C.Register_CONVOLUTION_REF()) }
+func Register_DEPTHWISE_CONV_2D() *tflite.ExpRegistration {
+	return wrap(C.Register_DEPTHWISE_CONV_2D())
+}
 func Register_DEPTHWISE_CONVOLUTION_REF() *tflite.ExpRegistration {
 	return wrap(C.Register_DEPTHWISE_CONVOLUTION_REF())
 }
@@ -173,11 +175,13 @@ func Register_EMBEDDING_LOOKUP_SPARSE() *tflite.ExpRegistration {
 func Register_FULLY_CONNECTED_REF() *tflite.ExpRegistration {
 	return wrap(C.Register_FULLY_CONNECTED_REF())
 }
-func Register_LSH_PROJECTION() *tflite.ExpRegistration    { return wrap(C.Register_LSH_PROJECTION()) }
-func Register_HASHTABLE_LOOKUP() *tflite.ExpRegistration  { return wrap(C.Register_HASHTABLE_LOOKUP()) }
-func Register_SOFTMAX() *tflite.ExpRegistration           { return wrap(C.Register_SOFTMAX()) }
-func Register_CONCATENATION_REF() *tflite.ExpRegistration { return wrap(C.Register_CONCATENATION_REF()) }
-func Register_ADD_REF() *tflite.ExpRegistration           { return wrap(C.Register_ADD_REF()) }
+func Register_LSH_PROJECTION() *tflite.ExpRegistration   { return wrap(C.Register_LSH_PROJECTION()) }
+func Register_HASHTABLE_LOOKUP() *tflite.ExpRegistration { return wrap(C.Register_HASHTABLE_LOOKUP()) }
+func Register_SOFTMAX() *tflite.ExpRegistration          { return wrap(C.Register_SOFTMAX()) }
+func Register_CONCATENATION_REF() *tflite.ExpRegistration {
+	return wrap(C.Register_CONCATENATION_REF())
+}
+func Register_ADD_REF() *tflite.ExpRegistration { return wrap(C.Register_ADD_REF()) }
 func Register_SPACE_TO_BATCH_ND_REF() *tflite.ExpRegistration {
 	return wrap(C.Register_SPACE_TO_BATCH_ND_REF())
 }
@@ -211,61 +215,65 @@ func Register_SKIP_GRAM() *tflite.ExpRegistration { return wrap(C.Register_SKIP_
 func Register_SPACE_TO_DEPTH_REF() *tflite.ExpRegistration {
 	return wrap(C.Register_SPACE_TO_DEPTH_REF())
 }
-func Register_GATHER() *tflite.ExpRegistration            { return wrap(C.Register_GATHER()) }
-func Register_TRANSPOSE_REF() *tflite.ExpRegistration     { return wrap(C.Register_TRANSPOSE_REF()) }
-func Register_MEAN_REF() *tflite.ExpRegistration          { return wrap(C.Register_MEAN_REF()) }
-func Register_SPLIT() *tflite.ExpRegistration             { return wrap(C.Register_SPLIT()) }
-func Register_SPLIT_V() *tflite.ExpRegistration           { return wrap(C.Register_SPLIT_V()) }
-func Register_SQUEEZE() *tflite.ExpRegistration           { return wrap(C.Register_SQUEEZE()) }
-func Register_STRIDED_SLICE_REF() *tflite.ExpRegistration { return wrap(C.Register_STRIDED_SLICE_REF()) }
-func Register_EXP() *tflite.ExpRegistration               { return wrap(C.Register_EXP()) }
-func Register_TOPK_V2() *tflite.ExpRegistration           { return wrap(C.Register_TOPK_V2()) }
-func Register_LOG() *tflite.ExpRegistration               { return wrap(C.Register_LOG()) }
-func Register_LOG_SOFTMAX_REF() *tflite.ExpRegistration   { return wrap(C.Register_LOG_SOFTMAX_REF()) }
-func Register_CAST() *tflite.ExpRegistration              { return wrap(C.Register_CAST()) }
-func Register_DEQUANTIZE() *tflite.ExpRegistration        { return wrap(C.Register_DEQUANTIZE()) }
-func Register_PRELU() *tflite.ExpRegistration             { return wrap(C.Register_PRELU()) }
-func Register_MAXIMUM() *tflite.ExpRegistration           { return wrap(C.Register_MAXIMUM()) }
-func Register_MINIMUM() *tflite.ExpRegistration           { return wrap(C.Register_MINIMUM()) }
-func Register_ARG_MAX() *tflite.ExpRegistration           { return wrap(C.Register_ARG_MAX()) }
-func Register_ARG_MIN() *tflite.ExpRegistration           { return wrap(C.Register_ARG_MIN()) }
-func Register_GREATER() *tflite.ExpRegistration           { return wrap(C.Register_GREATER()) }
-func Register_GREATER_EQUAL() *tflite.ExpRegistration     { return wrap(C.Register_GREATER_EQUAL()) }
-func Register_LESS() *tflite.ExpRegistration              { return wrap(C.Register_LESS()) }
-func Register_LESS_EQUAL() *tflite.ExpRegistration        { return wrap(C.Register_LESS_EQUAL()) }
-func Register_FLOOR_REF() *tflite.ExpRegistration         { return wrap(C.Register_FLOOR_REF()) }
-func Register_TILE() *tflite.ExpRegistration              { return wrap(C.Register_TILE()) }
-func Register_NEG() *tflite.ExpRegistration               { return wrap(C.Register_NEG()) }
-func Register_SUM() *tflite.ExpRegistration               { return wrap(C.Register_SUM()) }
-func Register_REDUCE_PROD() *tflite.ExpRegistration       { return wrap(C.Register_REDUCE_PROD()) }
-func Register_REDUCE_MAX() *tflite.ExpRegistration        { return wrap(C.Register_REDUCE_MAX()) }
-func Register_REDUCE_MIN() *tflite.ExpRegistration        { return wrap(C.Register_REDUCE_MIN()) }
-func Register_REDUCE_ANY() *tflite.ExpRegistration        { return wrap(C.Register_REDUCE_ANY()) }
-func Register_SELECT() *tflite.ExpRegistration            { return wrap(C.Register_SELECT()) }
-func Register_SLICE_REF() *tflite.ExpRegistration         { return wrap(C.Register_SLICE_REF()) }
-func Register_SIN() *tflite.ExpRegistration               { return wrap(C.Register_SIN()) }
-func Register_TRANSPOSECONV_REF() *tflite.ExpRegistration { return wrap(C.Register_TRANSPOSECONV_REF()) }
-func Register_EXPAND_DIMS() *tflite.ExpRegistration       { return wrap(C.Register_EXPAND_DIMS()) }
-func Register_SPARSE_TO_DENSE() *tflite.ExpRegistration   { return wrap(C.Register_SPARSE_TO_DENSE()) }
-func Register_EQUAL() *tflite.ExpRegistration             { return wrap(C.Register_EQUAL()) }
-func Register_NOT_EQUAL() *tflite.ExpRegistration         { return wrap(C.Register_NOT_EQUAL()) }
-func Register_SQRT() *tflite.ExpRegistration              { return wrap(C.Register_SQRT()) }
-func Register_RSQRT() *tflite.ExpRegistration             { return wrap(C.Register_RSQRT()) }
-func Register_SHAPE() *tflite.ExpRegistration             { return wrap(C.Register_SHAPE()) }
-func Register_POW() *tflite.ExpRegistration               { return wrap(C.Register_POW()) }
-func Register_FAKE_QUANT() *tflite.ExpRegistration        { return wrap(C.Register_FAKE_QUANT()) }
-func Register_PACK() *tflite.ExpRegistration              { return wrap(C.Register_PACK()) }
-func Register_ONE_HOT() *tflite.ExpRegistration           { return wrap(C.Register_ONE_HOT()) }
-func Register_LOGICAL_OR() *tflite.ExpRegistration        { return wrap(C.Register_LOGICAL_OR()) }
-func Register_LOGICAL_AND() *tflite.ExpRegistration       { return wrap(C.Register_LOGICAL_AND()) }
-func Register_LOGICAL_NOT() *tflite.ExpRegistration       { return wrap(C.Register_LOGICAL_NOT()) }
-func Register_UNPACK() *tflite.ExpRegistration            { return wrap(C.Register_UNPACK()) }
-func Register_FLOOR_DIV() *tflite.ExpRegistration         { return wrap(C.Register_FLOOR_DIV()) }
-func Register_SQUARE() *tflite.ExpRegistration            { return wrap(C.Register_SQUARE()) }
-func Register_ZEROS_LIKE() *tflite.ExpRegistration        { return wrap(C.Register_ZEROS_LIKE()) }
-func Register_FLOOR_MOD() *tflite.ExpRegistration         { return wrap(C.Register_FLOOR_MOD()) }
-func Register_RANGE() *tflite.ExpRegistration             { return wrap(C.Register_RANGE()) }
-func Register_LEAKY_RELU() *tflite.ExpRegistration        { return wrap(C.Register_LEAKY_RELU()) }
+func Register_GATHER() *tflite.ExpRegistration        { return wrap(C.Register_GATHER()) }
+func Register_TRANSPOSE_REF() *tflite.ExpRegistration { return wrap(C.Register_TRANSPOSE_REF()) }
+func Register_MEAN_REF() *tflite.ExpRegistration      { return wrap(C.Register_MEAN_REF()) }
+func Register_SPLIT() *tflite.ExpRegistration         { return wrap(C.Register_SPLIT()) }
+func Register_SPLIT_V() *tflite.ExpRegistration       { return wrap(C.Register_SPLIT_V()) }
+func Register_SQUEEZE() *tflite.ExpRegistration       { return wrap(C.Register_SQUEEZE()) }
+func Register_STRIDED_SLICE_REF() *tflite.ExpRegistration {
+	return wrap(C.Register_STRIDED_SLICE_REF())
+}
+func Register_EXP() *tflite.ExpRegistration             { return wrap(C.Register_EXP()) }
+func Register_TOPK_V2() *tflite.ExpRegistration         { return wrap(C.Register_TOPK_V2()) }
+func Register_LOG() *tflite.ExpRegistration             { return wrap(C.Register_LOG()) }
+func Register_LOG_SOFTMAX_REF() *tflite.ExpRegistration { return wrap(C.Register_LOG_SOFTMAX_REF()) }
+func Register_CAST() *tflite.ExpRegistration            { return wrap(C.Register_CAST()) }
+func Register_DEQUANTIZE() *tflite.ExpRegistration      { return wrap(C.Register_DEQUANTIZE()) }
+func Register_PRELU() *tflite.ExpRegistration           { return wrap(C.Register_PRELU()) }
+func Register_MAXIMUM() *tflite.ExpRegistration         { return wrap(C.Register_MAXIMUM()) }
+func Register_MINIMUM() *tflite.ExpRegistration         { return wrap(C.Register_MINIMUM()) }
+func Register_ARG_MAX() *tflite.ExpRegistration         { return wrap(C.Register_ARG_MAX()) }
+func Register_ARG_MIN() *tflite.ExpRegistration         { return wrap(C.Register_ARG_MIN()) }
+func Register_GREATER() *tflite.ExpRegistration         { return wrap(C.Register_GREATER()) }
+func Register_GREATER_EQUAL() *tflite.ExpRegistration   { return wrap(C.Register_GREATER_EQUAL()) }
+func Register_LESS() *tflite.ExpRegistration            { return wrap(C.Register_LESS()) }
+func Register_LESS_EQUAL() *tflite.ExpRegistration      { return wrap(C.Register_LESS_EQUAL()) }
+func Register_FLOOR_REF() *tflite.ExpRegistration       { return wrap(C.Register_FLOOR_REF()) }
+func Register_TILE() *tflite.ExpRegistration            { return wrap(C.Register_TILE()) }
+func Register_NEG() *tflite.ExpRegistration             { return wrap(C.Register_NEG()) }
+func Register_SUM() *tflite.ExpRegistration             { return wrap(C.Register_SUM()) }
+func Register_REDUCE_PROD() *tflite.ExpRegistration     { return wrap(C.Register_REDUCE_PROD()) }
+func Register_REDUCE_MAX() *tflite.ExpRegistration      { return wrap(C.Register_REDUCE_MAX()) }
+func Register_REDUCE_MIN() *tflite.ExpRegistration      { return wrap(C.Register_REDUCE_MIN()) }
+func Register_REDUCE_ANY() *tflite.ExpRegistration      { return wrap(C.Register_REDUCE_ANY()) }
+func Register_SELECT() *tflite.ExpRegistration          { return wrap(C.Register_SELECT()) }
+func Register_SLICE_REF() *tflite.ExpRegistration       { return wrap(C.Register_SLICE_REF()) }
+func Register_SIN() *tflite.ExpRegistration             { return wrap(C.Register_SIN()) }
+func Register_TRANSPOSECONV_REF() *tflite.ExpRegistration {
+	return wrap(C.Register_TRANSPOSECONV_REF())
+}
+func Register_EXPAND_DIMS() *tflite.ExpRegistration     { return wrap(C.Register_EXPAND_DIMS()) }
+func Register_SPARSE_TO_DENSE() *tflite.ExpRegistration { return wrap(C.Register_SPARSE_TO_DENSE()) }
+func Register_EQUAL() *tflite.ExpRegistration           { return wrap(C.Register_EQUAL()) }
+func Register_NOT_EQUAL() *tflite.ExpRegistration       { return wrap(C.Register_NOT_EQUAL()) }
+func Register_SQRT() *tflite.ExpRegistration            { return wrap(C.Register_SQRT()) }
+func Register_RSQRT() *tflite.ExpRegistration           { return wrap(C.Register_RSQRT()) }
+func Register_SHAPE() *tflite.ExpRegistration           { return wrap(C.Register_SHAPE()) }
+func Register_POW() *tflite.ExpRegistration             { return wrap(C.Register_POW()) }
+func Register_FAKE_QUANT() *tflite.ExpRegistration      { return wrap(C.Register_FAKE_QUANT()) }
+func Register_PACK() *tflite.ExpRegistration            { return wrap(C.Register_PACK()) }
+func Register_ONE_HOT() *tflite.ExpRegistration         { return wrap(C.Register_ONE_HOT()) }
+func Register_LOGICAL_OR() *tflite.ExpRegistration      { return wrap(C.Register_LOGICAL_OR()) }
+func Register_LOGICAL_AND() *tflite.ExpRegistration     { return wrap(C.Register_LOGICAL_AND()) }
+func Register_LOGICAL_NOT() *tflite.ExpRegistration     { return wrap(C.Register_LOGICAL_NOT()) }
+func Register_UNPACK() *tflite.ExpRegistration          { return wrap(C.Register_UNPACK()) }
+func Register_FLOOR_DIV() *tflite.ExpRegistration       { return wrap(C.Register_FLOOR_DIV()) }
+func Register_SQUARE() *tflite.ExpRegistration          { return wrap(C.Register_SQUARE()) }
+func Register_ZEROS_LIKE() *tflite.ExpRegistration      { return wrap(C.Register_ZEROS_LIKE()) }
+func Register_FLOOR_MOD() *tflite.ExpRegistration       { return wrap(C.Register_FLOOR_MOD()) }
+func Register_RANGE() *tflite.ExpRegistration           { return wrap(C.Register_RANGE()) }
+func Register_LEAKY_RELU() *tflite.ExpRegistration      { return wrap(C.Register_LEAKY_RELU()) }
 func Register_SQUARED_DIFFERENCE() *tflite.ExpRegistration {
 	return wrap(C.Register_SQUARED_DIFFERENCE())
 }

--- a/tflite.go
+++ b/tflite.go
@@ -14,7 +14,7 @@ import (
 	"unsafe"
 
 	"github.com/mattn/go-pointer"
-	"github.com/mattn/go-tflite/delegates"
+	"github.com/tphakala/go-tflite/delegates"
 )
 
 //go:generate stringer -type TensorType,Status -output type_string.go .


### PR DESCRIPTION
## Summary

- Bump Go version from 1.21 to 1.25
- Add Go 1.24+ CGO optimization directives (`#cgo noescape`, `#cgo nocallback`) for improved performance
- Add `runtime.AddCleanup` for automatic resource cleanup (safety net for GC)
- Modernize codebase with `interface{}` → `any`

## CGO Optimizations Applied

| Directive | Effect | Files |
|-----------|--------|-------|
| `#cgo noescape` | Prevents heap allocation for arguments passed to C | tflite.go, xnnpack.go, edgetpu.go, external.go |
| `#cgo nocallback` | Eliminates callback safety checks for C functions | All CGO files |
| `runtime.AddCleanup` | Auto-cleanup by GC (Go 1.24+) | tflite.go (Model, Interpreter, InterpreterOptions) |

## Breaking Changes

None - `Delete()` methods are preserved for backward compatibility (marked deprecated).

## Test plan

- [ ] Verify builds with Go 1.25
- [ ] Run existing tests
- [ ] Benchmark inference performance to measure CGO optimization impact