### PR TITLE
Add CI: build tensorflowlite_c buildkit and run tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         env:
           TENSORFLOW_SRC: ${{ runner.temp }}/tensorflow_src
           OUT_DIR: ${{ github.workspace }}/dist
+          BUILDKIT_SUFFIX: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
 
       - name: Install buildkit into /usr/local
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,59 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  TENSORFLOW_VERSION: v2.17.1
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Cache bazel
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/bazel
+          key: bazel-${{ runner.os }}-${{ env.TENSORFLOW_VERSION }}
+
+      - name: Build buildkit
+        run: ./ci/build-buildkit.sh
+        env:
+          TENSORFLOW_SRC: ${{ runner.temp }}/tensorflow_src
+          OUT_DIR: ${{ github.workspace }}/dist
+
+      - name: Install buildkit into /usr/local
+        run: |
+          sudo tar xzf dist/go-tflite-buildkit-*.tar.gz -C /usr/local
+          sudo ldconfig
+
+      - name: Build
+        run: go build .
+
+      - name: Test
+        run: go test -v .
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: go-tflite-buildkit
+          path: dist/*.tar.gz
+
+      - name: Upload buildkit to release
+        if: github.event_name == 'release'
+        run: gh release upload "$GITHUB_REF_NAME" dist/*.tar.gz --clobber
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/ci/build-buildkit.sh
+++ b/ci/build-buildkit.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Build the go-tflite buildkit tarball.
+#
+# The buildkit is a tarball that, when extracted into /usr/local, provides
+# everything needed for `go build` of go-tflite to succeed:
+#
+#   include/tensorflow/lite/...      TensorFlow Lite headers (only the ones
+#                                    actually included, computed via gcc -M)
+#   lib/libtensorflowlite_c.so       TensorFlow Lite C API shared library
+#
+# Run from the go-tflite repository root.
+#
+# Environment variables:
+#   TENSORFLOW_VERSION  git tag/branch of tensorflow to build (default: v2.17.1)
+#   TENSORFLOW_SRC      where to clone/find the tensorflow source
+#   OUT_DIR             where to place the resulting tarball (default: ./dist)
+set -euo pipefail
+
+TENSORFLOW_VERSION=${TENSORFLOW_VERSION:-v2.17.1}
+TENSORFLOW_SRC=${TENSORFLOW_SRC:-$HOME/tensorflow_src}
+OUT_DIR=${OUT_DIR:-$PWD/dist}
+GO_TFLITE_ROOT=$PWD
+
+if [ ! -d "$TENSORFLOW_SRC" ]; then
+  git clone --depth 1 --branch "$TENSORFLOW_VERSION" \
+    https://github.com/tensorflow/tensorflow "$TENSORFLOW_SRC"
+fi
+
+cd "$TENSORFLOW_SRC"
+
+# Non-interactive configure: CPU only, no Android, plain gcc toolchain.
+export PYTHON_BIN_PATH=${PYTHON_BIN_PATH:-$(command -v python3)}
+export TF_NEED_CUDA=0
+export TF_NEED_ROCM=0
+export TF_NEED_CLANG=${TF_NEED_CLANG:-0}
+export TF_SET_ANDROID_WORKSPACE=0
+export CC_OPT_FLAGS=${CC_OPT_FLAGS:--O2}
+python3 configure.py
+
+bazel build -c opt //tensorflow/lite/c:tensorflowlite_c
+
+STAGE=$(mktemp -d)
+trap 'rm -rf "$STAGE"' EXIT
+mkdir -p "$STAGE/include" "$STAGE/lib"
+
+# Collect only the headers go-tflite actually includes, plus their transitive
+# includes, computed by the C preprocessor.
+grep -h '#include <tensorflow/' "$GO_TFLITE_ROOT"/*.go.h \
+  | sed 's/<\(.*\)>/"\1"/' > "$STAGE/probe.c"
+gcc -M -I. "$STAGE/probe.c" \
+  | tr ' \\' '\n' | grep '^tensorflow/lite/' | sort -u \
+  | while read -r f; do
+      install -D -m 644 "$f" "$STAGE/include/$f"
+    done
+install -m 755 bazel-bin/tensorflow/lite/c/libtensorflowlite_c.so "$STAGE/lib/"
+rm -f "$STAGE/probe.c"
+
+mkdir -p "$OUT_DIR"
+NAME=go-tflite-buildkit-$(date +%Y%m%d).tar.gz
+tar czf "$OUT_DIR/$NAME" -C "$STAGE" include lib
+echo "created: $OUT_DIR/$NAME"

--- a/ci/build-buildkit.sh
+++ b/ci/build-buildkit.sh
@@ -14,6 +14,8 @@
 #   TENSORFLOW_VERSION  git tag/branch of tensorflow to build (default: v2.17.1)
 #   TENSORFLOW_SRC      where to clone/find the tensorflow source
 #   OUT_DIR             where to place the resulting tarball (default: ./dist)
+#   BUILDKIT_SUFFIX     suffix of the tarball name, typically a go-tflite
+#                       release tag (default: today's date as YYYYMMDD)
 set -euo pipefail
 
 TENSORFLOW_VERSION=${TENSORFLOW_VERSION:-v2.17.1}
@@ -56,6 +58,6 @@ install -m 755 bazel-bin/tensorflow/lite/c/libtensorflowlite_c.so "$STAGE/lib/"
 rm -f "$STAGE/probe.c"
 
 mkdir -p "$OUT_DIR"
-NAME=go-tflite-buildkit-$(date +%Y%m%d).tar.gz
+NAME=go-tflite-buildkit-${BUILDKIT_SUFFIX:-$(date +%Y%m%d)}.tar.gz
 tar czf "$OUT_DIR/$NAME" -C "$STAGE" include lib
 echo "created: $OUT_DIR/$NAME"


### PR DESCRIPTION
Adds a GitHub Actions workflow and a buildkit build script.

## What this does

- `ci/build-buildkit.sh`: clones TensorFlow (pinned to `v2.17.1`, overridable via `TENSORFLOW_VERSION`), builds `//tensorflow/lite/c:tensorflowlite_c` with bazel, and assembles `go-tflite-buildkit-YYYYMMDD.tar.gz`. The tarball contains only the headers go-tflite actually includes (computed transitively via `gcc -M` from `*.go.h`, 10 headers for v2.17.1) plus `lib/libtensorflowlite_c.so` — 2.3MB total.
- `.github/workflows/ci.yml`: on push / PR / release / manual dispatch, builds the buildkit (with bazel cache), extracts it into `/usr/local`, then runs `go build .` and `go test -v .` **without any extra CGO flags** — so the test itself verifies the buildkit contract: extract into /usr/local and `go build` works. The tarball is uploaded as a workflow artifact, and attached to the release when one is published.

## Notes

- Compared to the v1.0.5 buildkit (361MB, uncompressed tar): drops `libtensorflow.so.2.8.0` (not linked by go-tflite), non-header files, and enables gzip.
- Only the root package is tested; `delegates/` need additional shared libraries not built here.
- First run takes ~30-60 min (bazel, uncached); subsequent runs reuse the actions cache.