### PR TITLE
Add weights cache support to the XNNPACK delegate

### DIFF
--- a/delegates/xnnpack/xnnpack.go
+++ b/delegates/xnnpack/xnnpack.go
@@ -15,6 +15,58 @@ import (
 
 type DelegateOptions struct {
 	NumThreads int32
+
+	// WeightsCache shares packed weights between the delegates of multiple
+	// interpreter instances running the same model. Optional.
+	WeightsCache *WeightsCache
+}
+
+// WeightsCache is a cache for packed weights that can be shared between
+// multiple delegate instances of the same model. After creating all
+// interpreters that share the cache, finalize it with FinalizeHard (fixed
+// number of instances, lowest memory) or FinalizeSoft (more instances may
+// be added later); inference fails until the cache is finalized. The cache
+// must outlive every delegate using it.
+type WeightsCache struct {
+	c *C.struct_TfLiteXNNPackDelegateWeightsCache
+}
+
+// NewWeightsCache creates a new weights cache. Prefer NewWeightsCacheWithSize
+// which can reduce memory bandwidth.
+func NewWeightsCache() *WeightsCache {
+	c := C.TfLiteXNNPackDelegateWeightsCacheCreate()
+	if c == nil {
+		return nil
+	}
+	return &WeightsCache{c: c}
+}
+
+// NewWeightsCacheWithSize creates a new weights cache that can hold up to
+// size bytes without growing.
+func NewWeightsCacheWithSize(size int) *WeightsCache {
+	c := C.TfLiteXNNPackDelegateWeightsCacheCreateWithSize(C.size_t(size))
+	if c == nil {
+		return nil
+	}
+	return &WeightsCache{c: c}
+}
+
+// FinalizeSoft finalizes the cache leaving room so that delegates created
+// afterwards can still use it when their weights hit the cache.
+func (w *WeightsCache) FinalizeSoft() bool {
+	return bool(C.TfLiteXNNPackDelegateWeightsCacheFinalizeSoft(w.c))
+}
+
+// FinalizeHard freezes the cache and resizes it to the smallest possible
+// memory; no delegate can be added afterwards.
+func (w *WeightsCache) FinalizeHard() bool {
+	return bool(C.TfLiteXNNPackDelegateWeightsCacheFinalizeHard(w.c))
+}
+
+// Delete the weights cache. Only call this after every delegate using the
+// cache has been deleted.
+func (w *WeightsCache) Delete() {
+	C.TfLiteXNNPackDelegateWeightsCacheDelete(w.c)
 }
 
 // Delegate is the tflite delegate
@@ -26,6 +78,9 @@ func New(options DelegateOptions) delegates.Delegater {
 	var d *C.TfLiteDelegate
 	coptions := C.TfLiteXNNPackDelegateOptionsDefault()
 	coptions.num_threads = C.int32_t(options.NumThreads)
+	if options.WeightsCache != nil {
+		coptions.weights_cache = options.WeightsCache.c
+	}
 	d = C.TfLiteXNNPackDelegateCreate(&coptions)
 	if d == nil {
 		return nil

--- a/delegates/xnnpack/xnnpack_test.go
+++ b/delegates/xnnpack/xnnpack_test.go
@@ -1,0 +1,82 @@
+package xnnpack_test
+
+import (
+	"testing"
+
+	"github.com/mattn/go-tflite"
+	"github.com/mattn/go-tflite/delegates/xnnpack"
+)
+
+func invokeXOR(t *testing.T, interpreter *tflite.Interpreter) {
+	t.Helper()
+
+	tests := []struct {
+		input []float32
+		want  int
+	}{
+		{input: []float32{0, 0}, want: 0},
+		{input: []float32{0, 1}, want: 1},
+		{input: []float32{1, 0}, want: 1},
+		{input: []float32{1, 1}, want: 0},
+	}
+
+	for _, test := range tests {
+		float32s := interpreter.GetInputTensor(0).Float32s()
+		float32s[0], float32s[1] = test.input[0], test.input[1]
+		if interpreter.Invoke() != tflite.OK {
+			t.Fatal("invoke failed")
+		}
+
+		float32s = interpreter.GetOutputTensor(0).Float32s()
+		got := int(float32s[0] + 0.5)
+
+		if got != test.want {
+			t.Fatalf("want %v but got %v", test.want, got)
+		}
+	}
+}
+
+func TestWeightsCache(t *testing.T) {
+	model := tflite.NewModelFromFile("../../testdata/xor_model.tflite")
+	if model == nil {
+		t.Fatal("cannot load model")
+	}
+	defer model.Delete()
+
+	cache := xnnpack.NewWeightsCache()
+	if cache == nil {
+		t.Fatal("cannot create weights cache")
+	}
+	defer cache.Delete()
+
+	var interpreters []*tflite.Interpreter
+	for i := 0; i < 2; i++ {
+		options := tflite.NewInterpreterOptions()
+		defer options.Delete()
+		delegate := xnnpack.New(xnnpack.DelegateOptions{NumThreads: 1, WeightsCache: cache})
+		if delegate == nil {
+			t.Fatal("cannot create delegate")
+		}
+		defer delegate.Delete()
+		options.AddDelegate(delegate)
+
+		interpreter := tflite.NewInterpreter(model, options)
+		if interpreter == nil {
+			t.Fatal("cannot create interpreter")
+		}
+		defer interpreter.Delete()
+
+		if interpreter.AllocateTensors() != tflite.OK {
+			t.Fatal("allocate failed")
+		}
+		interpreters = append(interpreters, interpreter)
+	}
+
+	if !cache.FinalizeHard() {
+		t.Fatal("cannot finalize weights cache")
+	}
+
+	for _, interpreter := range interpreters {
+		invokeXOR(t, interpreter)
+	}
+}


### PR DESCRIPTION
Adds WeightsCache bindings so multiple interpreter instances of the same model can share packed weights, with a test running two interpreters over one cache.