### PR TITLE
Add cancellation APIs

### DIFF
--- a/tflite.go
+++ b/tflite.go
@@ -359,3 +359,17 @@ func (r *SignatureRunner) Delete() {
 		C.TfLiteSignatureRunnerDelete(r.r)
 	}
 }
+
+// EnableCancellation enable or disable cancellation for the interpreter
+// created with these options. When enabled, an in-flight Invoke call can be
+// aborted with Interpreter.Cancel.
+func (o *InterpreterOptions) EnableCancellation(enable bool) Status {
+	return Status(C.TfLiteInterpreterOptionsEnableCancellation(o.o, C.bool(enable)))
+}
+
+// Cancel cancel the in-flight invocation. The Invoke call aborted this way
+// returns an error status. Requires EnableCancellation on the options used
+// to create the interpreter.
+func (i *Interpreter) Cancel() Status {
+	return Status(C.TfLiteInterpreterCancel(i.i))
+}

--- a/tflite_experimental.go
+++ b/tflite_experimental.go
@@ -385,3 +385,9 @@ func (t *Tensor) GetString(index int) string {
 	offset2 := int(*(*C.int32_t)(unsafe.Pointer(ptr + uintptr(4*(index+2)))))
 	return string((*((*[1<<31 - 1]uint8)(unsafe.Pointer(ptr))))[offset1:offset2])
 }
+
+// Cancel cancel the in-flight invocation of the signature runner. Requires
+// EnableCancellation on the options used to create the interpreter.
+func (r *SignatureRunner) Cancel() Status {
+	return Status(C.TfLiteSignatureRunnerCancel(r.r))
+}


### PR DESCRIPTION
Adds EnableCancellation, Interpreter.Cancel and SignatureRunner.Cancel. Based on #60 because SignatureRunner.Cancel needs the SignatureRunner type.