### PR TITLE
Improve the gophernotes image

### DIFF
--- a/docker/gophernotes/Dockerfile
+++ b/docker/gophernotes/Dockerfile
@@ -63,7 +63,7 @@ RUN mkdir -p /tmp/warm && cd /tmp/warm \
  && cd / && rm -rf /tmp/warm
 
 WORKDIR /notebooks
-COPY go-tflite.ipynb .
+COPY go-tflite.ipynb iris.ipynb ./
 RUN cp "$(go env GOMODCACHE)/github.com/mattn/go-tflite@${GO_TFLITE_VERSION}/testdata/xor_model.tflite" .
 
 EXPOSE 8888

--- a/docker/gophernotes/Dockerfile
+++ b/docker/gophernotes/Dockerfile
@@ -6,7 +6,7 @@
 # The TensorFlow Lite C libraries come from the go-tflite buildkit that CI
 # attaches to releases, so no bazel build is involved.
 
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 
 FROM golang:${GO_VERSION}-trixie AS build
 
@@ -32,6 +32,9 @@ ARG BUILDKIT_VERSION=v1.0.7
 
 COPY --from=build /usr/local/go /usr/local/go
 ENV GOPATH=/go
+# Plugins gomacro compiles at runtime must match the toolchain gophernotes
+# itself was built with, so never let go auto-switch toolchains.
+ENV GOTOOLCHAIN=local
 ENV PATH=/opt/jupyter/bin:/go/bin:/usr/local/go/bin:$PATH
 
 RUN apt-get update \

--- a/docker/gophernotes/iris.ipynb
+++ b/docker/gophernotes/iris.ipynb
@@ -1,0 +1,104 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Train and run an iris classifier, all in Go\n\nTrain a tiny neural network on Fisher's iris dataset with hand-written\nbackprop/Adam, write it out as a TensorFlow Lite flatbuffer, and run it with\ngo-tflite — no Python, no TensorFlow. Adapted from\n[go-iris-tflite](https://github.com/mattn/go-iris-tflite)."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import (\n    \"fmt\"\n    \"io\"\n    \"net/http\"\n    \"os\"\n)\nos.MkdirAll(\"data\", 0755)\nresp, err := http.Get(\"https://raw.githubusercontent.com/mattn/go-iris-tflite/main/data/iris.csv\")\nif err != nil { panic(err) }\nf, _ := os.Create(\"data/iris.csv\")\nio.Copy(f, resp.Body)\nf.Close()\nresp.Body.Close()"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import \"github.com/mattn/go-iris-tflite/iris\"\nx, y, err := iris.Load(\"data/iris.csv\")\nfmt.Println(len(x), \"flowers\", err)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## The model\n\n`dense(4→8) tanh, dense(8→3) softmax` — 91 parameters, trained with Adam."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import (\n    \"math\"\n    \"math/rand\"\n)\n\nconst (\n    inputs  = iris.Dim\n    hidden  = 8\n    classes = 3\n\n    epochs    = 400\n    batchSize = 16\n\n    lr      = 0.001\n    beta1   = 0.9\n    beta2   = 0.999\n    epsilon = 1e-7\n)\n\ntype stats struct {\n    mean, std [inputs]float64\n}\n\nfunc newStats(x [][inputs]float64) stats {\n    var s stats\n    for _, v := range x {\n        for i, f := range v {\n            s.mean[i] += f\n        }\n    }\n    for i := range s.mean {\n        s.mean[i] /= float64(len(x))\n    }\n    for _, v := range x {\n        for i, f := range v {\n            d := f - s.mean[i]\n            s.std[i] += d * d\n        }\n    }\n    for i := range s.std {\n        s.std[i] = math.Sqrt(s.std[i] / float64(len(x)))\n    }\n    return s\n}\n\nfunc (s stats) apply(v [inputs]float64) []float64 {\n    out := make([]float64, inputs)\n    for i, f := range v {\n        out[i] = (f - s.mean[i]) / s.std[i]\n    }\n    return out\n}\n\ntype dense struct {\n    in, out        int\n    w, b           []float64\n    mw, vw, mb, vb []float64\n}\n\nfunc newDense(in, out int, r *rand.Rand) *dense {\n    d := &dense{\n        in: in, out: out,\n        w: make([]float64, in*out), b: make([]float64, out),\n        mw: make([]float64, in*out), vw: make([]float64, in*out),\n        mb: make([]float64, out), vb: make([]float64, out),\n    }\n    limit := math.Sqrt(6.0 / float64(in+out))\n    for i := range d.w {\n        d.w[i] = (r.Float64()*2 - 1) * limit\n    }\n    return d\n}\n\nfunc (d *dense) apply(gw, gb []float64, t int) {\n    alpha := lr * math.Sqrt(1-math.Pow(beta2, float64(t))) / (1 - math.Pow(beta1, float64(t)))\n    adam := func(w, m, v, g []float64) {\n        for i, gi := range g {\n            m[i] = beta1*m[i] + (1-beta1)*gi\n            v[i] = beta2*v[i] + (1-beta2)*gi*gi\n            w[i] -= alpha * m[i] / (math.Sqrt(v[i]) + epsilon)\n        }\n    }\n    adam(d.w, d.mw, d.vw, gw)\n    adam(d.b, d.mb, d.vb, gb)\n}"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "func forward(l1, l2 *dense, x []float64, h *[hidden]float64, p *[classes]float64) {\n    copy(h[:], l1.b)\n    for i, v := range x {\n        w := l1.w[i*hidden : (i+1)*hidden]\n        for j := range h {\n            h[j] += v * w[j]\n        }\n    }\n    for j := range h {\n        h[j] = math.Tanh(h[j])\n    }\n\n    copy(p[:], l2.b)\n    for j := range h {\n        w := l2.w[j*classes : (j+1)*classes]\n        for k := range p {\n            p[k] += h[j] * w[k]\n        }\n    }\n    max := p[0]\n    for _, v := range p[1:] {\n        if v > max {\n            max = v\n        }\n    }\n    var sum float64\n    for k := range p {\n        p[k] = math.Exp(p[k] - max)\n        sum += p[k]\n    }\n    for k := range p {\n        p[k] /= sum\n    }\n}\n\ntype grad struct {\n    w1, b1, w2, b2 []float64\n}\n\nfunc zero(v []float64) {\n    for i := range v {\n        v[i] = 0\n    }\n}\n\nfunc step(l1, l2 *dense, x, y []float64, invN float64, g *grad) {\n    var h [hidden]float64\n    var p [classes]float64\n    forward(l1, l2, x, &h, &p)\n\n    var d2 [classes]float64\n    for k := range d2 {\n        d2[k] = (p[k] - y[k]) * invN\n        g.b2[k] += d2[k]\n    }\n\n    var d1 [hidden]float64\n    for j := range h {\n        w := l2.w[j*classes : (j+1)*classes]\n        gw := g.w2[j*classes : (j+1)*classes]\n        var dh float64\n        for k, d := range d2 {\n            gw[k] += h[j] * d\n            dh += w[k] * d\n        }\n        d1[j] = dh * (1 - h[j]*h[j])\n        g.b1[j] += d1[j]\n    }\n    for i, v := range x {\n        gw := g.w1[i*hidden : (i+1)*hidden]\n        for j := range d1 {\n            gw[j] += v * d1[j]\n        }\n    }\n}\n\nfunc train(r *rand.Rand, trX [][]float64, trY []int) (*dense, *dense) {\n    l1 := newDense(inputs, hidden, r)\n    l2 := newDense(hidden, classes, r)\n    onehot := make([][]float64, len(trY))\n    for i, label := range trY {\n        onehot[i] = make([]float64, classes)\n        onehot[i][label] = 1\n    }\n    idx := make([]int, len(trX))\n    for i := range idx {\n        idx[i] = i\n    }\n    g := &grad{\n        w1: make([]float64, inputs*hidden),\n        b1: make([]float64, hidden),\n        w2: make([]float64, hidden*classes),\n        b2: make([]float64, classes),\n    }\n    t := 0\n    for epoch := 1; epoch <= epochs; epoch++ {\n        r.Shuffle(len(idx), func(i, j int) { idx[i], idx[j] = idx[j], idx[i] })\n        for lo := 0; lo < len(idx); lo += batchSize {\n            hi := lo + batchSize\n            if hi > len(idx) {\n                hi = len(idx)\n            }\n            invN := 1 / float64(hi-lo)\n            zero(g.w1)\n            zero(g.b1)\n            zero(g.w2)\n            zero(g.b2)\n            for _, i := range idx[lo:hi] {\n                step(l1, l2, trX[i], onehot[i], invN, g)\n            }\n            t++\n            l2.apply(g.w2, g.b2, t)\n            l1.apply(g.w1, g.b1, t)\n        }\n    }\n    return l1, l2\n}\n\nfunc argmax(v []float64) int {\n    best := 0\n    for i, x := range v {\n        if x > v[best] {\n            best = i\n        }\n    }\n    return best\n}"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Train on all 150 flowers"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import \"time\"\n\ns := newStats(x)\ntrX := make([][]float64, len(x))\nfor i, v := range x {\n    trX[i] = s.apply(v)\n}\nstarted := time.Now()\nl1, l2 := train(rand.New(rand.NewSource(1)), trX, y)\nok := 0\nfor i := range x {\n    var h [hidden]float64\n    var p [classes]float64\n    forward(l1, l2, trX[i], &h, &p)\n    if argmax(p[:]) == y[i] {\n        ok++\n    }\n}\nfmt.Printf(\"%d/%d on the training data (%v)\\n\", ok, len(x), time.Since(started).Round(time.Millisecond))\n\n// Fold the standardization into layer 1 so the model takes raw centimeters.\nfor i := 0; i < l1.in; i++ {\n    w := l1.w[i*l1.out : (i+1)*l1.out]\n    for j := range w {\n        w[j] /= s.std[i]\n        l1.b[j] -= s.mean[i] * w[j]\n    }\n}"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Write the model as a TensorFlow Lite flatbuffer\n\nThe schema is small enough to emit by hand (see\n`tensorflow/lite/schema/schema.fbs`)."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import (\n    \"encoding/binary\"\n    flatbuffers \"github.com/google/flatbuffers/go\"\n)\n\nconst (\n    opFullyConnected = 9\n    opSoftmax        = 25\n    opTanh           = 28\n\n    optionsFullyConnected = 8\n    optionsSoftmax        = 9\n)\n\nfunc floatBytes(v []float64) []byte {\n    b := make([]byte, 4*len(v))\n    for i, x := range v {\n        binary.LittleEndian.PutUint32(b[i*4:], math.Float32bits(float32(x)))\n    }\n    return b\n}\n\nfunc transposed(d *dense) []float64 {\n    t := make([]float64, len(d.w))\n    for i := 0; i < d.in; i++ {\n        for j := 0; j < d.out; j++ {\n            t[j*d.in+i] = d.w[i*d.out+j]\n        }\n    }\n    return t\n}\n\nfunc fbIntVector(b *flatbuffers.Builder, vals []int32) flatbuffers.UOffsetT {\n    b.StartVector(4, len(vals), 4)\n    for i := len(vals) - 1; i >= 0; i-- {\n        b.PrependInt32(vals[i])\n    }\n    return b.EndVector(len(vals))\n}\n\nfunc fbOffsetVector(b *flatbuffers.Builder, offs []flatbuffers.UOffsetT) flatbuffers.UOffsetT {\n    b.StartVector(4, len(offs), 4)\n    for i := len(offs) - 1; i >= 0; i-- {\n        b.PrependUOffsetT(offs[i])\n    }\n    return b.EndVector(len(offs))\n}\n\nfunc fbBuffer(b *flatbuffers.Builder, data []byte) flatbuffers.UOffsetT {\n    var off flatbuffers.UOffsetT\n    if len(data) > 0 {\n        b.Prep(16, len(data))\n        off = b.CreateByteVector(data)\n    }\n    b.StartObject(1)\n    if len(data) > 0 {\n        b.PrependUOffsetTSlot(0, off, 0)\n    }\n    return b.EndObject()\n}\n\nfunc fbTensor(b *flatbuffers.Builder, name string, shape []int32, buffer int32) flatbuffers.UOffsetT {\n    nameOff := b.CreateString(name)\n    shapeOff := fbIntVector(b, shape)\n    b.StartObject(4)\n    b.PrependUOffsetTSlot(0, shapeOff, 0)\n    b.PrependUint32Slot(2, uint32(buffer), 0)\n    b.PrependUOffsetTSlot(3, nameOff, 0)\n    return b.EndObject()\n}\n\nfunc fbOperatorCode(b *flatbuffers.Builder, code int32) flatbuffers.UOffsetT {\n    b.StartObject(4)\n    b.PrependInt8Slot(0, int8(code), 0)\n    b.PrependInt32Slot(3, code, 0)\n    return b.EndObject()\n}\n\nfunc fbOperator(b *flatbuffers.Builder, opcodeIndex uint32, ins, outs []int32, optionsType byte, options flatbuffers.UOffsetT) flatbuffers.UOffsetT {\n    inOff := fbIntVector(b, ins)\n    outOff := fbIntVector(b, outs)\n    b.StartObject(5)\n    b.PrependUint32Slot(0, opcodeIndex, 0)\n    b.PrependUOffsetTSlot(1, inOff, 0)\n    b.PrependUOffsetTSlot(2, outOff, 0)\n    if optionsType != 0 {\n        b.PrependByteSlot(3, optionsType, 0)\n        b.PrependUOffsetTSlot(4, options, 0)\n    }\n    return b.EndObject()\n}\n\nfunc buildTFLite(l1, l2 *dense) []byte {\n    b := flatbuffers.NewBuilder(16 * 1024)\n\n    buffers := []flatbuffers.UOffsetT{\n        fbBuffer(b, nil),\n        fbBuffer(b, floatBytes(transposed(l1))),\n        fbBuffer(b, floatBytes(l1.b)),\n        fbBuffer(b, floatBytes(transposed(l2))),\n        fbBuffer(b, floatBytes(l2.b)),\n    }\n\n    tensors := []flatbuffers.UOffsetT{\n        fbTensor(b, \"input\", []int32{1, inputs}, 0),\n        fbTensor(b, \"dense/kernel\", []int32{hidden, inputs}, 1),\n        fbTensor(b, \"dense/bias\", []int32{hidden}, 2),\n        fbTensor(b, \"dense/BiasAdd\", []int32{1, hidden}, 0),\n        fbTensor(b, \"tanh\", []int32{1, hidden}, 0),\n        fbTensor(b, \"dense_1/kernel\", []int32{classes, hidden}, 3),\n        fbTensor(b, \"dense_1/bias\", []int32{classes}, 4),\n        fbTensor(b, \"dense_1/BiasAdd\", []int32{1, classes}, 0),\n        fbTensor(b, \"output\", []int32{1, classes}, 0),\n    }\n\n    opcodes := []flatbuffers.UOffsetT{\n        fbOperatorCode(b, opFullyConnected),\n        fbOperatorCode(b, opTanh),\n        fbOperatorCode(b, opSoftmax),\n    }\n\n    b.StartObject(4)\n    fcOpts1 := b.EndObject()\n    b.StartObject(4)\n    fcOpts2 := b.EndObject()\n    b.StartObject(1)\n    b.PrependFloat32Slot(0, 1.0, 0.0)\n    smOpts := b.EndObject()\n\n    operators := []flatbuffers.UOffsetT{\n        fbOperator(b, 0, []int32{0, 1, 2}, []int32{3}, optionsFullyConnected, fcOpts1),\n        fbOperator(b, 1, []int32{3}, []int32{4}, 0, 0),\n        fbOperator(b, 0, []int32{4, 5, 6}, []int32{7}, optionsFullyConnected, fcOpts2),\n        fbOperator(b, 2, []int32{7}, []int32{8}, optionsSoftmax, smOpts),\n    }\n\n    subgraphName := b.CreateString(\"main\")\n    tensorsOff := fbOffsetVector(b, tensors)\n    inputsOff := fbIntVector(b, []int32{0})\n    outputsOff := fbIntVector(b, []int32{8})\n    operatorsOff := fbOffsetVector(b, operators)\n    b.StartObject(5)\n    b.PrependUOffsetTSlot(0, tensorsOff, 0)\n    b.PrependUOffsetTSlot(1, inputsOff, 0)\n    b.PrependUOffsetTSlot(2, outputsOff, 0)\n    b.PrependUOffsetTSlot(3, operatorsOff, 0)\n    b.PrependUOffsetTSlot(4, subgraphName, 0)\n    subgraph := b.EndObject()\n\n    description := b.CreateString(\"Iris species classifier, trained in pure Go.\")\n    opcodesOff := fbOffsetVector(b, opcodes)\n    subgraphsOff := fbOffsetVector(b, []flatbuffers.UOffsetT{subgraph})\n    buffersOff := fbOffsetVector(b, buffers)\n    b.StartObject(5)\n    b.PrependUint32Slot(0, 3, 0)\n    b.PrependUOffsetTSlot(1, opcodesOff, 0)\n    b.PrependUOffsetTSlot(2, subgraphsOff, 0)\n    b.PrependUOffsetTSlot(3, description, 0)\n    b.PrependUOffsetTSlot(4, buffersOff, 0)\n    model := b.EndObject()\n\n    b.FinishWithFileIdentifier(model, []byte(\"TFL3\"))\n    return b.FinishedBytes()\n}\n\nerr = os.WriteFile(\"iris_model.tflite\", buildTFLite(l1, l2), 0644)\nfmt.Println(\"wrote iris_model.tflite\", err)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Load the flatbuffer with go-tflite and classify"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import \"github.com/mattn/go-tflite\"\n\nmodel := tflite.NewModelFromFile(\"iris_model.tflite\")\noptions := tflite.NewInterpreterOptions()\ninterpreter := tflite.NewInterpreter(model, options)\ninterpreter.AllocateTensors()"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "correct := 0\nfor i, f := range x {\n    in := interpreter.GetInputTensor(0).Float32s()\n    for j, v := range f {\n        in[j] = float32(v)\n    }\n    interpreter.Invoke()\n    p := interpreter.GetOutputTensor(0).Float32s()\n    best := 0\n    for k := range p {\n        if p[k] > p[best] {\n            best = k\n        }\n    }\n    if best == y[i] {\n        correct++\n    }\n}\nfmt.Printf(\"TFLite inference: %d/%d correct\\n\", correct, len(x))"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "// Classify a new flower: sepal 6.1x2.8cm, petal 4.7x1.2cm.\nin := interpreter.GetInputTensor(0).Float32s()\ncopy(in, []float32{6.1, 2.8, 4.7, 1.2})\ninterpreter.Invoke()\np := interpreter.GetOutputTensor(0).Float32s()\nfor i, name := range iris.Names {\n    fmt.Printf(\"%-10s %5.1f%%\\n\", name, p[i]*100)\n}"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Go",
+   "language": "go",
+   "name": "go"
+  },
+  "language_info": {
+   "name": "go"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docker/gophernotes/run.sh
+++ b/docker/gophernotes/run.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Start Jupyter + gophernotes with a host directory mounted at /notebooks.
+#
+#   run.sh [directory]   directory to work in (default: current directory)
+set -e
+dir=$(cd "${1:-.}" && pwd)
+exec docker run --rm -it -p 8888:8888 -v "$dir":/notebooks \
+  ghcr.io/mattn/go-tflite/gophernotes


### PR DESCRIPTION
Builds with Go 1.26 and pins GOTOOLCHAIN so runtime plugin compilation matches the kernel binary, adds a notebook that trains the iris classifier in pure Go and runs it with go-tflite, and adds run.sh for mounting a host directory.