### PR TITLE
Return nil from NewInterpreter for a nil model

### DIFF
--- a/tflite.go
+++ b/tflite.go
@@ -119,6 +119,9 @@ type Interpreter struct {
 
 // NewInterpreter create new Interpreter.
 func NewInterpreter(model *Model, options *InterpreterOptions) *Interpreter {
+	if model == nil || model.m == nil {
+		return nil
+	}
 	var o *C.TfLiteInterpreterOptions
 	if options != nil {
 		o = options.o

--- a/tflite_test.go
+++ b/tflite_test.go
@@ -179,3 +179,16 @@ func TestModelWithErrorReporter(t *testing.T) {
 	}
 	t.Logf("reported: %q", messages)
 }
+
+func TestNewInterpreterNilModel(t *testing.T) {
+	model := NewModelFromFile("testdata/no_such_model.tflite")
+	if model != nil {
+		t.Fatal("expected nil model for a missing file")
+	}
+	if interpreter := NewInterpreter(model, nil); interpreter != nil {
+		t.Fatal("expected nil interpreter for a nil model")
+	}
+	if interpreter := NewInterpreter(nil, nil); interpreter != nil {
+		t.Fatal("expected nil interpreter for a nil model")
+	}
+}


### PR DESCRIPTION
Passing the nil model that NewModelFromFile returns on failure used to crash with a nil pointer dereference; now NewInterpreter returns nil like its own failure path.