### PR TITLE
Add a Binder launch button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,17 @@
 # go-tflite
 
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mattn/go-tflite/master?labpath=iris.ipynb)
+
 Go binding for TensorFlow Lite
 
 ![](https://raw.githubusercontent.com/mattn/go-tflite/master/screenshots/screenshot.png)
+
+## Try it in your browser
+
+Click [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/mattn/go-tflite/master?labpath=iris.ipynb)
+to launch a Jupyter notebook with go-tflite preinstalled and train the iris
+classifier right in the browser, no install needed. The same image is
+available as `ghcr.io/mattn/go-tflite/gophernotes` (see docker/gophernotes).
 
 ## Usage
 

--- a/binder/Dockerfile
+++ b/binder/Dockerfile
@@ -1,0 +1,17 @@
+# mybinder.org launcher for the gophernotes image: reuse the prebuilt
+# container and just add the unprivileged user that Binder runs as.
+FROM ghcr.io/mattn/go-tflite/gophernotes:latest
+
+ARG NB_USER=jovyan
+ARG NB_UID=1000
+ENV HOME=/home/${NB_USER}
+
+RUN useradd -m -u ${NB_UID} -s /bin/bash ${NB_USER} \
+ && cp /usr/local/share/gophernotes-examples/* ${HOME}/ \
+ && mkdir -p ${HOME}/.cache \
+ && cp -r /root/.cache/go-build ${HOME}/.cache/go-build \
+ && chown -R ${NB_UID} ${HOME} /go
+
+ENTRYPOINT []
+WORKDIR ${HOME}
+USER ${NB_USER}


### PR DESCRIPTION
Adds a binder/Dockerfile that reuses the ghcr.io gophernotes image and a launch badge in the README, so the iris notebook can be tried on mybinder.org without installing anything.